### PR TITLE
fix: unignore frontend/src/lib and commit missing lib files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,203 @@
+/**
+ * checkDK API client
+ *
+ * Usage:
+ *   import { analyzeDockerCompose, analyzeKubernetes, predictPodHealth } from '@/lib/api'
+ *
+ * The base URL is controlled by the VITE_API_URL env variable.
+ * In development (without Docker) it falls back to http://localhost:8000
+ * so the Vite dev server proxy in vite.config.ts forwards /api/* calls.
+ */
+
+// Resolve the API base URL at runtime:
+//  1. Runtime injection from env.sh via window.__CHECKDK_ENV__ (Docker)
+//  2. Vite build-time env var (local dev with explicit override)
+//  3. /api — nginx proxy path (Docker production, same-origin)
+const _env = (window as unknown as { __CHECKDK_ENV__?: { CHECKDK_API_URL?: string } }).__CHECKDK_ENV__
+const API_BASE = (
+  _env?.CHECKDK_API_URL ||
+  import.meta.env.VITE_API_URL ||
+  '/api'
+).replace(/\/+$/, '')
+
+// ── Shared types ──────────────────────────────────────────────────────────────
+
+export type Severity = 'critical' | 'warning' | 'info'
+
+export interface Issue {
+  type: string
+  severity: Severity
+  message: string
+  file_path?: string
+  line_number?: number
+  service_name?: string
+  details?: Record<string, unknown>
+}
+
+export interface Fix {
+  description: string
+  steps: string[]
+  code_snippet?: string
+  auto_applicable?: boolean
+  explanation?: string
+  root_cause?: string
+}
+
+export interface AnalysisResult {
+  success: boolean
+  issues: Issue[]
+  fixes: Fix[]
+  warnings: string[]
+}
+
+// ── Predict types ─────────────────────────────────────────────────────────────
+
+export interface PredictRequest {
+  cpu: number
+  memory: number
+  disk?: number
+  latency?: number
+  restarts?: number
+  probe_failures?: number
+  cpu_pressure?: number
+  mem_pressure?: number
+  age?: number
+  service?: string
+  platform?: 'docker' | 'kubernetes'
+  no_ai?: boolean
+}
+
+export interface MLPrediction {
+  label: string
+  confidence: number
+  risk_level: 'low' | 'medium' | 'high' | 'critical'
+  is_failure: boolean
+}
+
+export interface LLMAssessment {
+  assessment: string
+  root_cause: string
+  recommendations: string[]
+}
+
+export interface PredictResponse {
+  prediction: MLPrediction
+  assessment?: LLMAssessment
+}
+
+// ── Health ────────────────────────────────────────────────────────────────────
+
+export async function apiHealth(): Promise<{ status: string }> {
+  const res = await fetch(`${API_BASE}/health`)
+  if (!res.ok) throw new Error(`Health check failed: ${res.statusText}`)
+  return res.json()
+}
+
+// ── Analysis ──────────────────────────────────────────────────────────────────
+
+/**
+ * Analyse a Docker Compose YAML string.
+ * @param content  Raw YAML text (e.g. read from a file input or a textarea)
+ */
+export async function analyzeDockerCompose(content: string): Promise<AnalysisResult> {
+  const res = await fetch(`${API_BASE}/analyze/docker-compose`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) {
+    const detail = await res.text()
+    throw new Error(`Docker Compose analysis failed (${res.status}): ${detail}`)
+  }
+  return res.json()
+}
+
+/**
+ * Analyse a Kubernetes manifest YAML string.
+ * @param content  Raw YAML text (supports multi-document --- separators)
+ */
+export async function analyzeKubernetes(content: string): Promise<AnalysisResult> {
+  const res = await fetch(`${API_BASE}/analyze/kubernetes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) {
+    const detail = await res.text()
+    throw new Error(`Kubernetes analysis failed (${res.status}): ${detail}`)
+  }
+  return res.json()
+}
+
+// ── User history & patterns ───────────────────────────────────────────────────
+
+export interface HistoryItem {
+  id: string
+  analysisId?: string
+  configType: string
+  filename: string
+  score: number
+  status: string
+  issueCount: number
+  topCategories: string[]
+  createdAt: string
+  analyzedAt?: string
+  summary?: string
+  aiProvider?: string
+}
+
+export interface PatternItem {
+  category: string
+  label: string
+  count: number
+}
+
+function authHeaders(token: string): HeadersInit {
+  return { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+}
+
+export async function fetchUserHistory(token: string): Promise<HistoryItem[]> {
+  const res = await fetch(`${API_BASE}/user/history`, { headers: authHeaders(token) })
+  if (!res.ok) throw new Error(`Failed to load history (${res.status})`)
+  const data = await res.json()
+  // Normalize backend snake_case / alternate field names to what the UI expects
+  return (data.history as Record<string, unknown>[]).map((h) => ({
+    id: (h.id ?? h.analysisId) as string,
+    analysisId: h.analysisId as string | undefined,
+    configType: h.configType as string,
+    filename: h.filename as string,
+    score: h.score as number,
+    status: h.status as string,
+    issueCount: h.issueCount as number,
+    topCategories: (h.topCategories ?? []) as string[],
+    createdAt: (h.createdAt ?? h.analyzedAt) as string,
+    analyzedAt: h.analyzedAt as string | undefined,
+    summary: h.summary as string | undefined,
+    aiProvider: h.aiProvider as string | undefined,
+  }))
+}
+
+export async function fetchUserPatterns(token: string): Promise<PatternItem[]> {
+  const res = await fetch(`${API_BASE}/user/patterns`, { headers: authHeaders(token) })
+  if (!res.ok) throw new Error(`Failed to load patterns (${res.status})`)
+  const data = await res.json()
+  return data.patterns as PatternItem[]
+}
+
+// ── Pod health prediction ─────────────────────────────────────────────────────
+
+/**
+ * Run the Random Forest model and (optionally) LLM against pod runtime metrics.
+ */
+export async function predictPodHealth(metrics: PredictRequest): Promise<PredictResponse> {
+  const res = await fetch(`${API_BASE}/predict`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(metrics),
+  })
+  if (!res.ok) {
+    const detail = await res.text()
+    throw new Error(`Pod health prediction failed (${res.status}): ${detail}`)
+  }
+  return res.json()
+}

--- a/frontend/src/lib/mockAnalyzer.ts
+++ b/frontend/src/lib/mockAnalyzer.ts
@@ -1,0 +1,110 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// lib/mockAnalyzer.ts
+// Lightweight client-side rule-based analyzer used when the user is not
+// authenticated. No network requests — runs entirely in the browser.
+// Returns the same AnalysisResult shape as the backend playground endpoint.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { AnalysisResult, AnalysisIssue } from '../services/aiAnalysis';
+
+interface Rule {
+  test: (content: string) => boolean;
+  issue: AnalysisIssue;
+}
+
+const RULES: Rule[] = [
+  {
+    test: (c) => /:latest/.test(c) || (/image:\s*\S+$/.test(c) && !/:/.test(c.match(/image:\s*(\S+)/)?.[1] ?? ':')),
+    issue: {
+      severity: 'medium',
+      title: 'Unpinned image tag',
+      description: 'One or more images use ":latest" or no tag, making builds non-reproducible.',
+      recommendation: 'Pin a specific version, e.g. nginx:1.25.3',
+      category: 'image_tag',
+    },
+  },
+  {
+    test: (c) => /privileged:\s*true/.test(c),
+    issue: {
+      severity: 'high',
+      title: 'Privileged container',
+      description: 'A container runs in privileged mode, granting full host access.',
+      recommendation: 'Remove "privileged: true" and use specific capabilities instead.',
+      category: 'security',
+    },
+  },
+  {
+    test: (c) => /(password|secret|api_key|token)\s*=\s*\S+/i.test(c),
+    issue: {
+      severity: 'high',
+      title: 'Possible hardcoded secret',
+      description: 'A secret or API key may be hardcoded in the config.',
+      recommendation: 'Use environment variable references or a secrets manager.',
+      category: 'hardcoded_secret',
+    },
+  },
+  {
+    test: (c) => /services:/.test(c) && !/resources:/.test(c),
+    issue: {
+      severity: 'medium',
+      title: 'No resource limits',
+      description: 'Services have no CPU/memory limits defined.',
+      recommendation: 'Add deploy.resources.limits with cpus and memory.',
+      category: 'resource_limits',
+    },
+  },
+  {
+    test: (c) => /kind:\s*Deployment/.test(c) && !/livenessProbe|readinessProbe/.test(c),
+    issue: {
+      severity: 'medium',
+      title: 'Missing liveness/readiness probes',
+      description: 'Kubernetes Deployment has no liveness or readiness probes.',
+      recommendation: 'Add livenessProbe and readinessProbe to your container spec.',
+      category: 'probe',
+    },
+  },
+  {
+    test: (c) => /kind:\s*Deployment/.test(c) && !/resources:/.test(c),
+    issue: {
+      severity: 'medium',
+      title: 'No resource requests/limits',
+      description: 'Kubernetes containers have no CPU or memory requests/limits.',
+      recommendation: 'Set resources.requests and resources.limits on each container.',
+      category: 'resource_limits',
+    },
+  },
+];
+
+export async function mockAnalyze(
+  content: string,
+): Promise<AnalysisResult> {
+  const issues: AnalysisIssue[] = RULES
+    .filter((r) => r.test(content))
+    .map((r) => r.issue);
+
+  const criticalCount = issues.filter((i) => i.severity === 'critical').length;
+  const highCount = issues.filter((i) => i.severity === 'high').length;
+  const mediumCount = issues.filter((i) => i.severity === 'medium').length;
+
+  const penalty = criticalCount * 25 + highCount * 15 + mediumCount * 8;
+  const score = Math.max(0, Math.min(100, 100 - penalty));
+
+  const status =
+    score >= 80 ? 'secure'
+    : score >= 50 ? 'warning'
+    : 'critical';
+
+  const summary =
+    issues.length === 0
+      ? 'No obvious issues detected by the quick scanner. Sign in for a full AI-powered audit.'
+      : `Found ${issues.length} issue${issues.length > 1 ? 's' : ''} with the quick scanner. Sign in for a full AI-powered audit.`;
+
+  return {
+    score,
+    status,
+    summary,
+    issues,
+    highlights: [],
+    provider: 'mock',
+  };
+}

--- a/frontend/src/lib/mockApi.ts
+++ b/frontend/src/lib/mockApi.ts
@@ -1,0 +1,210 @@
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type IssueSeverity = 'critical' | 'warning' | 'info';
+
+export interface AnalysisIssue {
+  severity: IssueSeverity;
+  message: string;
+  explanation: string;
+  fix?: string;
+  line?: number;
+  file: string;
+}
+
+export interface AnalysisReport {
+  id: string;
+  status: 'passed' | 'warnings' | 'failed';
+  configType: 'docker-compose' | 'kubernetes';
+  command: string;
+  files: string[];
+  errors: AnalysisIssue[];
+  timestamp: string;
+  executionTimeMs: number;
+}
+
+export interface DashboardStats {
+  totalRuns: number;
+  passedRuns: number;
+  warningRuns: number;
+  failedRuns: number;
+  runsPerDay: { date: string; count: number }[];
+  mostCommonErrors: { type: string; count: number }[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function formatRelativeTime(timestamp: string): string {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const MOCK_REPORTS: AnalysisReport[] = [
+  {
+    id: '1',
+    status: 'failed',
+    configType: 'docker-compose',
+    command: 'checkdk docker compose up -d',
+    files: ['docker-compose.yml'],
+    timestamp: new Date(Date.now() - 5 * 60_000).toISOString(),
+    executionTimeMs: 312,
+    errors: [
+      {
+        severity: 'critical',
+        message: 'Port 8080 is bound on multiple services',
+        explanation: 'Services "api" and "worker" both attempt to bind host port 8080, which will cause a conflict at runtime.',
+        fix: 'Change the worker service to use a different port, e.g. "8081:8080".',
+        line: 14,
+        file: 'docker-compose.yml',
+      },
+      {
+        severity: 'warning',
+        message: 'No resource limits set on service "db"',
+        explanation: 'Without CPU and memory limits the database container can consume all host resources and starve other services.',
+        fix: 'Add a deploy.resources.limits block with appropriate cpu and memory values.',
+        line: 27,
+        file: 'docker-compose.yml',
+      },
+      {
+        severity: 'warning',
+        message: 'Image tag "latest" used for service "api"',
+        explanation: 'Using the "latest" tag makes builds non-reproducible and can cause unexpected breakage on re-pulls.',
+        fix: 'Pin to a specific version, e.g. myapp:1.4.2.',
+        line: 8,
+        file: 'docker-compose.yml',
+      },
+    ],
+  },
+  {
+    id: '2',
+    status: 'warnings',
+    configType: 'kubernetes',
+    command: 'checkdk kubectl apply -f',
+    files: ['k8s-deployment.yml', 'k8s-service.yml'],
+    timestamp: new Date(Date.now() - 2 * 3600_000).toISOString(),
+    executionTimeMs: 487,
+    errors: [
+      {
+        severity: 'warning',
+        message: 'Liveness probe missing on container "backend"',
+        explanation: 'Without a liveness probe Kubernetes cannot detect a deadlocked container and will not restart it automatically.',
+        fix: 'Add a livenessProbe block targeting the /health endpoint.',
+        line: 33,
+        file: 'k8s-deployment.yml',
+      },
+      {
+        severity: 'info',
+        message: 'Readiness probe interval is very short (2s)',
+        explanation: 'A 2 s probe interval increases API-server load; 10–15 s is typical for most workloads.',
+        file: 'k8s-deployment.yml',
+      },
+    ],
+  },
+  {
+    id: '3',
+    status: 'passed',
+    configType: 'docker-compose',
+    command: 'checkdk docker compose up -d',
+    files: ['docker-compose.prod.yml'],
+    timestamp: new Date(Date.now() - 24 * 3600_000).toISOString(),
+    executionTimeMs: 278,
+    errors: [],
+  },
+  {
+    id: '4',
+    status: 'failed',
+    configType: 'kubernetes',
+    command: 'checkdk kubectl apply -f',
+    files: ['k8s-complex.yml'],
+    timestamp: new Date(Date.now() - 2 * 24 * 3600_000).toISOString(),
+    executionTimeMs: 601,
+    errors: [
+      {
+        severity: 'critical',
+        message: 'Hardcoded secret in environment variable "DB_PASSWORD"',
+        explanation: 'Plain-text secrets in manifests are stored unencrypted in the cluster etcd and any git history.',
+        fix: 'Use a Kubernetes Secret resource and reference it with secretKeyRef.',
+        line: 45,
+        file: 'k8s-complex.yml',
+      },
+      {
+        severity: 'warning',
+        message: 'No resource requests set — scheduler cannot place pod optimally',
+        explanation: 'Without resource requests the Kubernetes scheduler has no signal for bin-packing and may over-commit nodes.',
+        fix: 'Add resources.requests.cpu and resources.requests.memory to your container spec.',
+        file: 'k8s-complex.yml',
+      },
+    ],
+  },
+  {
+    id: '5',
+    status: 'warnings',
+    configType: 'docker-compose',
+    command: 'checkdk docker compose up -d',
+    files: ['docker-compose.yml'],
+    timestamp: new Date(Date.now() - 3 * 24 * 3600_000).toISOString(),
+    executionTimeMs: 295,
+    errors: [
+      {
+        severity: 'warning',
+        message: 'No healthcheck defined for service "redis"',
+        explanation: 'Docker will mark the container healthy immediately after start even if Redis is not yet accepting connections.',
+        fix: 'Add a HEALTHCHECK instruction or a healthcheck block using redis-cli ping.',
+        file: 'docker-compose.yml',
+      },
+    ],
+  },
+  {
+    id: '6',
+    status: 'passed',
+    configType: 'kubernetes',
+    command: 'checkdk kubectl apply -f',
+    files: ['k8s-deployment.yml'],
+    timestamp: new Date(Date.now() - 4 * 24 * 3600_000).toISOString(),
+    executionTimeMs: 390,
+    errors: [],
+  },
+];
+
+const MOCK_STATS: DashboardStats = {
+  totalRuns: MOCK_REPORTS.length,
+  passedRuns: MOCK_REPORTS.filter(r => r.status === 'passed').length,
+  warningRuns: MOCK_REPORTS.filter(r => r.status === 'warnings').length,
+  failedRuns: MOCK_REPORTS.filter(r => r.status === 'failed').length,
+  runsPerDay: [
+    { date: 'Mon', count: 3 },
+    { date: 'Tue', count: 5 },
+    { date: 'Wed', count: 2 },
+    { date: 'Thu', count: 7 },
+    { date: 'Fri', count: 4 },
+    { date: 'Sat', count: 1 },
+    { date: 'Sun', count: 6 },
+  ],
+  mostCommonErrors: [
+    { type: 'no_resource_limits', count: 8 },
+    { type: 'latest_image_tag', count: 6 },
+    { type: 'missing_healthcheck', count: 5 },
+    { type: 'port_conflict', count: 3 },
+    { type: 'hardcoded_secret', count: 2 },
+    { type: 'missing_probes', count: 2 },
+  ],
+};
+
+// ── API functions (swap for real fetch() calls when backend is ready) ─────────
+
+export async function fetchReports(): Promise<AnalysisReport[]> {
+  await new Promise(r => setTimeout(r, 400)); // simulate network latency
+  return MOCK_REPORTS;
+}
+
+export async function fetchStats(): Promise<DashboardStats> {
+  await new Promise(r => setTimeout(r, 250));
+  return MOCK_STATS;
+}


### PR DESCRIPTION
This pull request introduces new client-side API modules for both real and mock analysis functionality, enabling the frontend to interact with backend endpoints and to provide offline analysis and dashboard statistics. The main changes include the addition of a comprehensive API client (`api.ts`), a lightweight rule-based analyzer for unauthenticated users (`mockAnalyzer.ts`), and a mock API for dashboard data and reports (`mockApi.ts`). These additions improve the frontend's ability to handle both authenticated and unauthenticated workflows and provide richer user feedback.

**API client for backend interaction:**

* Added `frontend/src/lib/api.ts` containing typed API client functions for health checks, Docker Compose and Kubernetes analysis, pod health prediction, user history, and user pattern retrieval. The module includes detailed type definitions and runtime environment resolution for flexible deployment.

**Client-side analysis for unauthenticated users:**

* Added `frontend/src/lib/mockAnalyzer.ts`, a lightweight rule-based analyzer that scans Docker Compose and Kubernetes YAML files in the browser, returning issues and scores in the same shape as backend analysis. This enables quick feedback without requiring authentication or network requests.

**Mock API for dashboard and reports:**

* Added `frontend/src/lib/mockApi.ts`, providing mock data and API functions for dashboard statistics and analysis reports, including helper functions and sample error data. This supports development and demo workflows before backend endpoints are available.