### PR TITLE
feat: WebSocket goes direct to App Runner, fix init defaults, bump v0.2.4

### DIFF
--- a/cli/checkdkcli/__init__.py
+++ b/cli/checkdkcli/__init__.py
@@ -1,3 +1,3 @@
 """checkDK CLI package."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/cli/checkdkcli/client.py
+++ b/cli/checkdkcli/client.py
@@ -21,11 +21,33 @@ def get_api_url() -> str:
     Priority:
         1. $CHECKDK_API_URL environment variable
         2. ~/.checkdk/.env  (loaded by python-dotenv at startup)
-        3. Fallback to https://checkdk.app/api (production) — override with
-           CHECKDK_API_URL=http://localhost:8000 for local dev
+        3. Fallback to https://checkdk.app/api (production)
     """
     url = os.getenv("CHECKDK_API_URL", "https://checkdk.app/api").strip().rstrip("/")
     return url
+
+
+def get_ws_url() -> str:
+    """Return the WebSocket base URL for real-time monitoring.
+
+    CloudFront does not support WebSocket upgrades on the free plan, so the
+    WebSocket connection goes directly to App Runner instead of via checkdk.app.
+
+    Priority:
+        1. $CHECKDK_WS_URL environment variable
+        2. ~/.checkdk/.env  (CHECKDK_WS_URL=...)
+        3. Fallback to the App Runner service URL (wss://)
+    """
+    stored = os.getenv("CHECKDK_WS_URL")
+    if stored:
+        return stored.strip().rstrip("/")
+    env_file = Path.home() / ".checkdk" / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            if line.startswith("CHECKDK_WS_URL="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    # Direct App Runner URL — bypasses CloudFront which blocks WebSocket
+    return "wss://m7fijvmhiq.us-east-1.awsapprunner.com"
 
 
 def get_stored_token() -> Optional[str]:

--- a/cli/checkdkcli/commands/init.py
+++ b/cli/checkdkcli/commands/init.py
@@ -16,7 +16,7 @@ def init_cmd() -> None:
     """Configure checkDK CLI (set API URL, API keys, etc.)."""
     console.print("[bold]checkDK CLI configuration[/]\n")
 
-    default_url = os.getenv("CHECKDK_API_URL", "http://localhost:8000")
+    default_url = os.getenv("CHECKDK_API_URL", "https://checkdk.app/api")
     api_url = console.input(
         f"  Backend API URL [[dim]{default_url}[/]]: "
     ).strip() or default_url
@@ -33,10 +33,19 @@ def init_cmd() -> None:
         ]
 
     existing.append(f"CHECKDK_API_URL={api_url}")
+
+    default_ws = os.getenv("CHECKDK_WS_URL", "wss://m7fijvmhiq.us-east-1.awsapprunner.com")
+    ws_url = console.input(
+        f"  WebSocket URL (for monitor) [[dim]{default_ws}[/]]: "
+    ).strip() or default_ws
+    existing = [l for l in existing if not l.startswith("CHECKDK_WS_URL=")]
+    existing.append(f"CHECKDK_WS_URL={ws_url}")
+
     env_path.write_text("\n".join(existing) + "\n")
 
     console.print(
         f"\n[bold green]✓ Saved to:[/] {env_path}\n"
-        f"  [dim]CHECKDK_API_URL={api_url}[/]\n\n"
-        "Tip: You can also set [bold cyan]CHECKDK_API_URL[/] as a shell environment variable."
+        f"  [dim]CHECKDK_API_URL={api_url}[/]\n"
+        f"  [dim]CHECKDK_WS_URL={ws_url}[/]\n\n"
+        "Tip: You can also set these as shell environment variables."
     )

--- a/cli/checkdkcli/commands/monitor.py
+++ b/cli/checkdkcli/commands/monitor.py
@@ -14,6 +14,8 @@ from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
+from ..client import get_ws_url
+
 _console = Console()
 
 
@@ -95,9 +97,7 @@ def monitor_cmd() -> None:
               help="Stop after N seconds (0 = run until Ctrl-C)")
 @click.option("--interval", default=5, show_default=True, type=int,
               help="Polling interval in seconds")
-@click.option("--api-url", envvar="CHECKDK_API_URL", default="https://checkdk.app/api",
-              help="Backend base URL")
-def monitor_docker(container: str, duration: int, interval: int, api_url: str) -> None:
+def monitor_docker(container: str, duration: int, interval: int) -> None:
     """Stream live Docker container metrics and predict failure risk.
 
     \b
@@ -114,7 +114,7 @@ def monitor_docker(container: str, duration: int, interval: int, api_url: str) -
 
     import websocket as ws_lib
 
-    ws_url = api_url.replace("http://", "ws://").replace("https://", "wss://") + "/ws/monitor"
+    ws_url = get_ws_url() + "/ws/monitor"
     history: list[dict] = []
     start = time.time()
 
@@ -168,8 +168,7 @@ def monitor_docker(container: str, duration: int, interval: int, api_url: str) -
 @click.option("--namespace", "-n", default="default", show_default=True)
 @click.option("--duration", default=0, type=int, help="Stop after N seconds (0 = Ctrl-C)")
 @click.option("--interval", default=5, show_default=True, type=int)
-@click.option("--api-url", envvar="CHECKDK_API_URL", default="https://checkdk.app/api")
-def monitor_k8s(pod: str, namespace: str, duration: int, interval: int, api_url: str) -> None:
+def monitor_k8s(pod: str, namespace: str, duration: int, interval: int) -> None:
     """Stream live Kubernetes pod metrics and predict failure risk.
 
     \b
@@ -185,7 +184,7 @@ def monitor_k8s(pod: str, namespace: str, duration: int, interval: int, api_url:
 
     import websocket as ws_lib
 
-    ws_url = api_url.replace("http://", "ws://").replace("https://", "wss://") + "/ws/monitor"
+    ws_url = get_ws_url() + "/ws/monitor"
     history: list[dict] = []
     start = time.time()
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "checkdk-cli"
-version = "0.2.3"
+version = "0.2.4"
 description = "checkDK CLI – AI-powered Docker/Kubernetes issue detector and pod failure predictor"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request updates the checkDK CLI to add support for configuring and using a dedicated WebSocket URL for real-time monitoring, separating it from the API URL. This improves reliability for live metrics streaming, especially given CloudFront limitations. The changes also update the CLI prompts and environment variable handling to reflect this new separation.

Configuration and environment variable improvements:

* Added a new `get_ws_url()` function in `client.py` to determine the WebSocket base URL, prioritizing environment variables and `.env` file, with fallback to the direct App Runner URL.
* Updated the `init_cmd()` in `commands/init.py` to prompt for and store `CHECKDK_WS_URL` alongside `CHECKDK_API_URL` in the `.env` file, and improved console messaging to include both variables.
* Changed the default API URL in `init_cmd()` to use the production endpoint (`https://checkdk.app/api`) instead of localhost.

Monitor command improvements:

* Refactored `monitor_docker` and `monitor_k8s` commands in `commands/monitor.py` to use `get_ws_url()` for constructing the WebSocket URL, removing the need to derive it from the API URL and eliminating the `--api-url` option. [[1]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL98-R100) [[2]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL117-R117) [[3]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL171-R171) [[4]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL188-R187)
* Imported `get_ws_url` in `commands/monitor.py` to support the above changes.

Version bump:

* Updated the CLI package version to `0.2.4` in both `__init__.py` and `pyproject.toml`. [[1]](diffhunk://#diff-00b794df52bc1860ff9fa1ba06655b635228d50488d1c6787cc962cb2f0f83f8L3-R3) [[2]](diffhunk://#diff-0c21298b23605dcadf25950579e3ada906093fa49e7c5f98eaa7f3d816c29d28L7-R7)