### PR TITLE
fix: bump CLI to 0.2.6, scope publish.yml to cli-v* tags only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   push:
     tags:
-      - "v*.*.*"   # e.g. v0.2.0
+      - "cli-v*.*.*"   # e.g. cli-v0.2.6  (avoids conflicts with npm-v* tags)
 
 permissions:
   contents: write       # create GitHub Release

--- a/cli/checkdkcli/__init__.py
+++ b/cli/checkdkcli/__init__.py
@@ -1,3 +1,3 @@
 """checkDK CLI package."""
 
-__version__ = "0.2.4"
+__version__ = "0.2.6"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "checkdk-cli"
-version = "0.2.4"
+version = "0.2.6"
 description = "checkDK CLI – AI-powered Docker/Kubernetes issue detector and pod failure predictor"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request makes a minor update to the release process and versioning for the `checkdk-cli` package. The most important changes are a version bump and an adjustment to the GitHub Actions workflow to avoid tag conflicts.

Versioning and release workflow updates:

* Updated the release tag pattern in `.github/workflows/publish.yml` to use `cli-v*.*.*` instead of `v*.*.*`, preventing conflicts with other tag types such as `npm-v*`.
* Bumped the package version from `0.2.4` to `0.2.6` in both `cli/checkdkcli/__init__.py` and `cli/pyproject.toml`. [[1]](diffhunk://#diff-00b794df52bc1860ff9fa1ba06655b635228d50488d1c6787cc962cb2f0f83f8L3-R3) [[2]](diffhunk://#diff-0c21298b23605dcadf25950579e3ada906093fa49e7c5f98eaa7f3d816c29d28L7-R7)