### PR TITLE
fix: replace WebSocket monitor with REST polling, bump to 0.2.8

### DIFF
--- a/cli/checkdkcli/__init__.py
+++ b/cli/checkdkcli/__init__.py
@@ -1,3 +1,3 @@
 """checkDK CLI package."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/cli/checkdkcli/commands/init.py
+++ b/cli/checkdkcli/commands/init.py
@@ -34,18 +34,10 @@ def init_cmd() -> None:
 
     existing.append(f"CHECKDK_API_URL={api_url}")
 
-    default_ws = os.getenv("CHECKDK_WS_URL", "wss://m7fijvmhiq.us-east-1.awsapprunner.com")
-    ws_url = console.input(
-        f"  WebSocket URL (for monitor) [[dim]{default_ws}[/]]: "
-    ).strip() or default_ws
-    existing = [l for l in existing if not l.startswith("CHECKDK_WS_URL=")]
-    existing.append(f"CHECKDK_WS_URL={ws_url}")
-
     env_path.write_text("\n".join(existing) + "\n")
 
     console.print(
         f"\n[bold green]✓ Saved to:[/] {env_path}\n"
-        f"  [dim]CHECKDK_API_URL={api_url}[/]\n"
-        f"  [dim]CHECKDK_WS_URL={ws_url}[/]\n\n"
-        "Tip: You can also set these as shell environment variables."
+        f"  [dim]CHECKDK_API_URL={api_url}[/]\n\n"
+        "Tip: You can also set this as a shell environment variable."
     )

--- a/cli/checkdkcli/commands/monitor.py
+++ b/cli/checkdkcli/commands/monitor.py
@@ -1,20 +1,24 @@
-"""checkdk monitor - real-time container/pod health monitoring over WebSocket."""
+"""checkdk monitor - real-time container/pod health monitoring via REST polling.
+
+Polls the /predict endpoint on each interval instead of using a WebSocket
+connection, which is blocked by the App Runner infrastructure layer.
+"""
 
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 import time
 from typing import Optional
 
 import click
+import requests
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
-from ..client import get_ws_url
+from ..client import get_api_url
 
 _console = Console()
 
@@ -22,6 +26,12 @@ _console = Console()
 def _risk_color(label: str) -> str:
     return {"healthy": "green", "warning": "yellow", "critical": "red"}.get(
         label.lower(), "white"
+    )
+
+
+def _level_color(level: str) -> str:
+    return {"low": "green", "medium": "yellow", "high": "red", "critical": "bold red"}.get(
+        level.lower(), "white"
     )
 
 
@@ -63,23 +73,59 @@ def _k8s_stats(pod: str, namespace: str) -> Optional[dict]:
     return {"cpu": _pct(parts[1]), "memory": _pct(parts[2])}
 
 
+def _predict(api_url: str, stats: dict, platform: str, service: str, no_ai: bool) -> Optional[dict]:
+    """POST to /predict and return the prediction dict, or None on error."""
+    try:
+        resp = requests.post(
+            f"{api_url}/predict",
+            json={
+                "cpu": stats["cpu"],
+                "memory": stats["memory"],
+                "disk": 50.0,
+                "latency": 10.0,
+                "restarts": 0,
+                "probe_failures": 0,
+                "cpu_pressure": 0,
+                "mem_pressure": 0,
+                "age": 60,
+                "service": service,
+                "platform": platform,
+                "no_ai": no_ai,
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        pred = data.get("prediction", {})
+        return {
+            "label":      pred.get("label", "unknown"),
+            "confidence": pred.get("confidence", 0.0),
+            "risk_level": pred.get("risk_level", "unknown"),
+        }
+    except Exception as exc:
+        _console.log(f"[dim red]Predict error: {exc}[/]")
+        return None
+
+
 def _build_table(history: list[dict]) -> Table:
     t = Table(title="checkDK Real-Time Monitor", expand=True)
     t.add_column("#",          style="dim",    width=4)
     t.add_column("CPU %",      style="cyan",   width=8)
     t.add_column("MEM %",      style="cyan",   width=8)
     t.add_column("Risk Label", width=12)
+    t.add_column("Risk Level", width=12)
     t.add_column("Confidence", width=12)
     t.add_column("Time",       style="dim")
     for i, row in enumerate(history[-20:], 1):
         label = row.get("label", "unknown")
+        level = row.get("risk_level", "unknown")
         conf  = row.get("confidence", 0.0)
-        col   = _risk_color(label)
         t.add_row(
             str(i),
             f"{row.get('cpu', 0):.1f}",
             f"{row.get('mem', 0):.1f}",
-            Text(label, style=f"bold {col}"),
+            Text(label, style=f"bold {_risk_color(label)}"),
+            Text(level, style=_level_color(level)),
             f"{conf:.2f}",
             row.get("ts", ""),
         )
@@ -97,36 +143,23 @@ def monitor_cmd() -> None:
               help="Stop after N seconds (0 = run until Ctrl-C)")
 @click.option("--interval", default=5, show_default=True, type=int,
               help="Polling interval in seconds")
-def monitor_docker(container: str, duration: int, interval: int) -> None:
+@click.option("--no-ai", is_flag=True, default=False,
+              help="Skip LLM analysis (faster, ML prediction only)")
+def monitor_docker(container: str, duration: int, interval: int, no_ai: bool) -> None:
     """Stream live Docker container metrics and predict failure risk.
 
     \b
     Example:
         checkdk monitor docker my-container
         checkdk monitor docker api --duration 120 --interval 3
+        checkdk monitor docker api --no-ai
     """
-    try:
-        import websocket  # noqa: F401
-    except ImportError:
-        _console.print("[bold red]Missing dependency:[/] install websocket-client")
-        _console.print("  pip install websocket-client")
-        sys.exit(1)
-
-    import websocket as ws_lib
-
-    ws_url = get_ws_url() + "/ws/monitor"
+    api_url = get_api_url()
     history: list[dict] = []
     start = time.time()
 
-    _console.print(f"[bold]Monitoring container:[/] [cyan]{container}[/]  [dim]{ws_url}[/]")
+    _console.print(f"[bold]Monitoring container:[/] [cyan]{container}[/]  [dim]{api_url}/predict[/]")
     _console.print("[dim]Press Ctrl-C to stop.[/]\n")
-
-    try:
-        sock = ws_lib.create_connection(ws_url, timeout=10)
-    except Exception as exc:
-        _console.print(f"[bold red]Cannot connect to WebSocket:[/] {exc}")
-        _console.print("[yellow]Is the backend running with WebSocket support?[/]")
-        sys.exit(1)
 
     try:
         with Live(_build_table(history), refresh_per_second=1) as live:
@@ -137,29 +170,20 @@ def monitor_docker(container: str, duration: int, interval: int) -> None:
                 if stats is None:
                     time.sleep(interval)
                     continue
-                payload = {
-                    "cpu_usage": stats["cpu"], "memory_usage": stats["memory"],
-                    "disk_usage": 50.0, "network_latency": 0.0,
-                    "restart_count": 0, "probe_failures": 0,
-                    "cpu_pressure": 0, "memory_pressure": 0,
-                    "pod_age_minutes": 60,
-                }
-                sock.send(json.dumps(payload))
-                raw = sock.recv()
-                resp = json.loads(raw)
-                history.append({
-                    "cpu": stats["cpu"], "mem": stats["memory"],
-                    "label": resp.get("label", "?"),
-                    "confidence": resp.get("confidence", 0.0),
-                    "ts": time.strftime("%H:%M:%S"),
-                })
-                live.update(_build_table(history))
+                pred = _predict(api_url, stats, platform="docker", service=container, no_ai=no_ai)
+                if pred:
+                    history.append({
+                        "cpu":        stats["cpu"],
+                        "mem":        stats["memory"],
+                        "label":      pred["label"],
+                        "risk_level": pred["risk_level"],
+                        "confidence": pred["confidence"],
+                        "ts":         time.strftime("%H:%M:%S"),
+                    })
+                    live.update(_build_table(history))
                 time.sleep(interval)
     except KeyboardInterrupt:
         pass
-    finally:
-        try: sock.close()
-        except: pass
     _console.print("\n[bold green]Monitor stopped.[/]")
 
 
@@ -168,34 +192,23 @@ def monitor_docker(container: str, duration: int, interval: int) -> None:
 @click.option("--namespace", "-n", default="default", show_default=True)
 @click.option("--duration", default=0, type=int, help="Stop after N seconds (0 = Ctrl-C)")
 @click.option("--interval", default=5, show_default=True, type=int)
-def monitor_k8s(pod: str, namespace: str, duration: int, interval: int) -> None:
+@click.option("--no-ai", is_flag=True, default=False,
+              help="Skip LLM analysis (faster, ML prediction only)")
+def monitor_k8s(pod: str, namespace: str, duration: int, interval: int, no_ai: bool) -> None:
     """Stream live Kubernetes pod metrics and predict failure risk.
 
     \b
     Example:
         checkdk monitor k8s my-pod -n production
         checkdk monitor k8s api-pod --duration 120
+        checkdk monitor k8s api-pod --no-ai
     """
-    try:
-        import websocket  # noqa: F401
-    except ImportError:
-        _console.print("[bold red]Missing dependency:[/] install websocket-client")
-        sys.exit(1)
-
-    import websocket as ws_lib
-
-    ws_url = get_ws_url() + "/ws/monitor"
+    api_url = get_api_url()
     history: list[dict] = []
     start = time.time()
 
-    _console.print(f"[bold]Monitoring pod:[/] [cyan]{pod}[/] (ns: {namespace})  [dim]{ws_url}[/]")
+    _console.print(f"[bold]Monitoring pod:[/] [cyan]{pod}[/] (ns: {namespace})  [dim]{api_url}/predict[/]")
     _console.print("[dim]Press Ctrl-C to stop.[/]\n")
-
-    try:
-        sock = ws_lib.create_connection(ws_url, timeout=10)
-    except Exception as exc:
-        _console.print(f"[bold red]Cannot connect to WebSocket:[/] {exc}")
-        sys.exit(1)
 
     try:
         with Live(_build_table(history), refresh_per_second=1) as live:
@@ -206,27 +219,18 @@ def monitor_k8s(pod: str, namespace: str, duration: int, interval: int) -> None:
                 if stats is None:
                     time.sleep(interval)
                     continue
-                payload = {
-                    "cpu_usage": stats["cpu"], "memory_usage": stats["memory"],
-                    "disk_usage": 50.0, "network_latency": 0.0,
-                    "restart_count": 0, "probe_failures": 0,
-                    "cpu_pressure": 0, "memory_pressure": 0,
-                    "pod_age_minutes": 60,
-                }
-                sock.send(json.dumps(payload))
-                raw = sock.recv()
-                resp = json.loads(raw)
-                history.append({
-                    "cpu": stats["cpu"], "mem": stats["memory"],
-                    "label": resp.get("label", "?"),
-                    "confidence": resp.get("confidence", 0.0),
-                    "ts": time.strftime("%H:%M:%S"),
-                })
-                live.update(_build_table(history))
+                pred = _predict(api_url, stats, platform="kubernetes", service=pod, no_ai=no_ai)
+                if pred:
+                    history.append({
+                        "cpu":        stats["cpu"],
+                        "mem":        stats["memory"],
+                        "label":      pred["label"],
+                        "risk_level": pred["risk_level"],
+                        "confidence": pred["confidence"],
+                        "ts":         time.strftime("%H:%M:%S"),
+                    })
+                    live.update(_build_table(history))
                 time.sleep(interval)
     except KeyboardInterrupt:
         pass
-    finally:
-        try: sock.close()
-        except: pass
     _console.print("\n[bold green]Monitor stopped.[/]")

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "checkdk-cli"
-version = "0.2.7"
+version = "0.2.8"
 description = "checkDK CLI – AI-powered Docker/Kubernetes issue detector and pod failure predictor"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -34,7 +34,6 @@ dependencies = [
     "requests>=2.31.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.0.0",
-    "websocket-client>=1.6.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request refactors the real-time monitoring functionality in the `checkdk-cli` package. The monitor command now uses REST polling of the `/predict` endpoint instead of WebSocket connections, due to infrastructure limitations. It also introduces risk level display and adds an option to skip LLM analysis for faster ML-only predictions. The WebSocket dependency is removed, and the CLI version is updated.

**Monitoring refactor and enhancements:**

* Changed the monitor commands (`monitor_docker` and `monitor_k8s` in `monitor.py`) to use REST polling of the `/predict` endpoint instead of WebSocket, addressing App Runner infrastructure limitations. [[1]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL1-R21) [[2]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL100-L130) [[3]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL171-L199)
* Added a new `--no-ai` option to both monitor commands, allowing users to skip LLM analysis for faster ML-only predictions. [[1]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL100-L130) [[2]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL171-L199)
* Introduced risk level display in the monitoring table, including color coding for risk levels. [[1]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dR32-R37) [[2]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dR76-R128)

**Dependency and version updates:**

* Removed the `websocket-client` dependency from `pyproject.toml` and the monitor command implementation, since WebSocket is no longer used. [[1]](diffhunk://#diff-0c21298b23605dcadf25950579e3ada906093fa49e7c5f98eaa7f3d816c29d28L37) [[2]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL100-L130) [[3]](diffhunk://#diff-8ed15dd0c3c5357897a2c08e0cb7088b4f777e947a4874ddfb0822bb8581650dL171-L199)
* Updated CLI version to `0.2.8` in both `__init__.py` and `pyproject.toml`. [[1]](diffhunk://#diff-00b794df52bc1860ff9fa1ba06655b635228d50488d1c6787cc962cb2f0f83f8L3-R3) [[2]](diffhunk://#diff-0c21298b23605dcadf25950579e3ada906093fa49e7c5f98eaa7f3d816c29d28L7-R7)

**Init command simplification:**

* Simplified the `init` command by removing the WebSocket URL configuration and related output.