### PR TITLE
add missing PyInstaller hidden imports + platform README.md files

### DIFF
--- a/cli/checkdk.spec
+++ b/cli/checkdk.spec
@@ -59,6 +59,15 @@ HIDDEN_IMPORTS = [
     "websocket._socket",
     "websocket._ssl_compat",
     "websocket._utils",
+    # stdlib modules used by auth.py / chaos.py / monitor.py that
+    # PyInstaller can miss (especially webbrowser with its dynamic
+    # browser-backend imports)
+    "webbrowser",
+    "http",
+    "http.server",
+    "socket",
+    "subprocess",
+    "threading",
 ]
 
 a = Analysis(

--- a/npm/@checkdk/cli-darwin-arm64/README.md
+++ b/npm/@checkdk/cli-darwin-arm64/README.md
@@ -1,0 +1,28 @@
+# @checkdk/cli-darwin-arm64
+
+macOS arm64 (Apple Silicon) platform binary for [`@checkdk/cli`](https://www.npmjs.com/package/@checkdk/cli).
+
+This package is installed automatically as an optional dependency — you should not install it directly.
+
+## Install the CLI
+
+```bash
+npm install -g @checkdk/cli
+```
+
+## Usage
+
+```bash
+checkdk --help
+checkdk auth login
+checkdk playground -f docker-compose.yml
+checkdk predict --cpu 85 --memory 78
+```
+
+See the [@checkdk/cli README](https://www.npmjs.com/package/@checkdk/cli) for full documentation.
+
+## Links
+
+- Main package: [@checkdk/cli](https://www.npmjs.com/package/@checkdk/cli)
+- GitHub: [radheshpai87/checkDK](https://github.com/radheshpai87/checkDK)
+- Website: [checkdk.app](https://checkdk.app)

--- a/npm/@checkdk/cli-darwin-arm64/package.json
+++ b/npm/@checkdk/cli-darwin-arm64/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/checkDK_AWS"
+    "url": "https://github.com/radheshpai87/checkDK"
   },
   "os": ["darwin"],
   "cpu": ["arm64"],
   "files": [
-    "bin/"
+    "bin/",
+    "README.md"
   ]
 }

--- a/npm/@checkdk/cli-darwin-x64/README.md
+++ b/npm/@checkdk/cli-darwin-x64/README.md
@@ -1,0 +1,31 @@
+# @checkdk/cli-darwin-x64
+
+macOS x64 (Intel) platform binary for [`@checkdk/cli`](https://www.npmjs.com/package/@checkdk/cli).
+
+> **Note:** A pre-built binary for Intel Macs is not currently available.
+> Install via pip instead: `pip install checkdk-cli`
+
+This package is installed automatically as an optional dependency — you should not install it directly.
+
+## Install the CLI
+
+```bash
+npm install -g @checkdk/cli
+```
+
+## Usage
+
+```bash
+checkdk --help
+checkdk auth login
+checkdk playground -f docker-compose.yml
+checkdk predict --cpu 85 --memory 78
+```
+
+See the [@checkdk/cli README](https://www.npmjs.com/package/@checkdk/cli) for full documentation.
+
+## Links
+
+- Main package: [@checkdk/cli](https://www.npmjs.com/package/@checkdk/cli)
+- GitHub: [radheshpai87/checkDK](https://github.com/radheshpai87/checkDK)
+- Website: [checkdk.app](https://checkdk.app)

--- a/npm/@checkdk/cli-darwin-x64/package.json
+++ b/npm/@checkdk/cli-darwin-x64/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/checkDK_AWS"
+    "url": "https://github.com/radheshpai87/checkDK"
   },
   "os": ["darwin"],
   "cpu": ["x64"],
   "files": [
-    "bin/"
+    "bin/",
+    "README.md"
   ]
 }

--- a/npm/@checkdk/cli-linux-arm64/README.md
+++ b/npm/@checkdk/cli-linux-arm64/README.md
@@ -1,0 +1,28 @@
+# @checkdk/cli-linux-arm64
+
+Linux arm64 platform binary for [`@checkdk/cli`](https://www.npmjs.com/package/@checkdk/cli).
+
+This package is installed automatically as an optional dependency — you should not install it directly.
+
+## Install the CLI
+
+```bash
+npm install -g @checkdk/cli
+```
+
+## Usage
+
+```bash
+checkdk --help
+checkdk auth login
+checkdk playground -f docker-compose.yml
+checkdk predict --cpu 85 --memory 78
+```
+
+See the [@checkdk/cli README](https://www.npmjs.com/package/@checkdk/cli) for full documentation.
+
+## Links
+
+- Main package: [@checkdk/cli](https://www.npmjs.com/package/@checkdk/cli)
+- GitHub: [radheshpai87/checkDK](https://github.com/radheshpai87/checkDK)
+- Website: [checkdk.app](https://checkdk.app)

--- a/npm/@checkdk/cli-linux-arm64/package.json
+++ b/npm/@checkdk/cli-linux-arm64/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/checkDK_AWS"
+    "url": "https://github.com/radheshpai87/checkDK"
   },
   "os": ["linux"],
   "cpu": ["arm64"],
   "files": [
-    "bin/"
+    "bin/",
+    "README.md"
   ]
 }

--- a/npm/@checkdk/cli-linux-x64/README.md
+++ b/npm/@checkdk/cli-linux-x64/README.md
@@ -1,0 +1,28 @@
+# @checkdk/cli-linux-x64
+
+Linux x64 platform binary for [`@checkdk/cli`](https://www.npmjs.com/package/@checkdk/cli).
+
+This package is installed automatically as an optional dependency — you should not install it directly.
+
+## Install the CLI
+
+```bash
+npm install -g @checkdk/cli
+```
+
+## Usage
+
+```bash
+checkdk --help
+checkdk auth login
+checkdk playground -f docker-compose.yml
+checkdk predict --cpu 85 --memory 78
+```
+
+See the [@checkdk/cli README](https://www.npmjs.com/package/@checkdk/cli) for full documentation.
+
+## Links
+
+- Main package: [@checkdk/cli](https://www.npmjs.com/package/@checkdk/cli)
+- GitHub: [radheshpai87/checkDK](https://github.com/radheshpai87/checkDK)
+- Website: [checkdk.app](https://checkdk.app)

--- a/npm/@checkdk/cli-linux-x64/package.json
+++ b/npm/@checkdk/cli-linux-x64/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/checkDK_AWS"
+    "url": "https://github.com/radheshpai87/checkDK"
   },
   "os": ["linux"],
   "cpu": ["x64"],
   "files": [
-    "bin/"
+    "bin/",
+    "README.md"
   ]
 }

--- a/npm/@checkdk/cli-win32-x64/README.md
+++ b/npm/@checkdk/cli-win32-x64/README.md
@@ -1,0 +1,28 @@
+# @checkdk/cli-win32-x64
+
+Windows x64 platform binary for [`@checkdk/cli`](https://www.npmjs.com/package/@checkdk/cli).
+
+This package is installed automatically as an optional dependency — you should not install it directly.
+
+## Install the CLI
+
+```bash
+npm install -g @checkdk/cli
+```
+
+## Usage
+
+```bash
+checkdk --help
+checkdk auth login
+checkdk playground -f docker-compose.yml
+checkdk predict --cpu 85 --memory 78
+```
+
+See the [@checkdk/cli README](https://www.npmjs.com/package/@checkdk/cli) for full documentation.
+
+## Links
+
+- Main package: [@checkdk/cli](https://www.npmjs.com/package/@checkdk/cli)
+- GitHub: [radheshpai87/checkDK](https://github.com/radheshpai87/checkDK)
+- Website: [checkdk.app](https://checkdk.app)

--- a/npm/@checkdk/cli-win32-x64/package.json
+++ b/npm/@checkdk/cli-win32-x64/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/checkDK_AWS"
+    "url": "https://github.com/radheshpai87/checkDK"
   },
   "os": ["win32"],
   "cpu": ["x64"],
   "files": [
-    "bin/"
+    "bin/",
+    "README.md"
   ]
 }

--- a/npm/@checkdk/cli/README.md
+++ b/npm/@checkdk/cli/README.md
@@ -68,5 +68,5 @@ handling work exactly as if you invoked the binary directly.
 ## Links
 
 - Documentation: <https://checkdk.app/docs>
-- Issues: <https://github.com/your-org/checkDK_AWS/issues>
+- Issues: <https://github.com/radheshpai87/checkDK/issues>
 - PyPI: <https://pypi.org/project/checkdk-cli/>

--- a/npm/@checkdk/cli/package.json
+++ b/npm/@checkdk/cli/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/checkDK_AWS"
+    "url": "https://github.com/radheshpai87/checkDK"
   },
   "homepage": "https://checkdk.app",
   "keywords": [


### PR DESCRIPTION
- Add webbrowser, http, http.server, socket, subprocess, threading to HIDDEN_IMPORTS in checkdk.spec — these stdlib modules are used by auth.py/chaos.py/monitor.py but PyInstaller misses them (especially webbrowser with its dynamic browser-backend imports), causing 'import error on line 11' in the frozen npm binary
- Create README.md for all 5 platform packages so npmjs.com pages show proper documentation instead of blank
- Add README.md to 'files' allowlist in each platform package.json so npm includes it in the published tarball
- Fix repository URLs from placeholder your-org/checkDK_AWS to radheshpai87/checkDK in all 6 package.json files + main README

None of these changes affect the pip-installed version of checkdk.

## Summary

<!-- What does this PR do? One or two sentences. -->

Closes #<!-- issue number, if applicable -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] CI / tooling

## Changes Made

<!-- Bullet list of what changed and why -->

- 
- 

## Testing

<!-- How did you test this? -->

- [ ] Backend: `pytest tests/ -v` passes
- [ ] Frontend: `npx tsc --noEmit` and `npm run lint` pass
- [ ] Manually tested locally with `docker compose up --build`

## Screenshots (if UI change)

<!-- Before / after screenshots or a short screen recording -->

## Checklist

- [ ] My branch is up to date with `main`
- [ ] I've kept this PR focused (one feature or fix)
- [ ] I've added/updated tests for any changed backend logic
- [ ] I've updated the README if this adds a user-visible change
- [ ] I haven't committed secrets, `.env` files, or build artifacts
