### PR TITLE
fix: resolve PyInstaller relative import error in npm binary

### DIFF
--- a/cli/bootstrap.py
+++ b/cli/bootstrap.py
@@ -1,0 +1,25 @@
+"""Bootstrap entry point for PyInstaller builds.
+
+PyInstaller executes the entry-point file as a top-level script (__main__),
+which means relative imports inside checkdkcli/ would fail with:
+
+    ImportError: attempted relative import with no known parent package
+
+This tiny wrapper uses an absolute import so that checkdkcli is loaded as
+a proper package and all relative imports within it resolve correctly.
+
+This file is ONLY used by PyInstaller (checkdk.spec) — the pip-installed
+CLI uses the entry point defined in pyproject.toml (checkdkcli.main:main),
+which is completely unaffected.
+"""
+
+import warnings
+
+# Suppress harmless RequestsDependencyWarning from requests when running
+# inside a PyInstaller frozen binary (charset_normalizer version detection
+# fails in the frozen environment).
+warnings.filterwarnings("ignore", message="Unable to find acceptable character detection dependency")
+
+from checkdkcli.main import main
+
+main()

--- a/cli/checkdk.spec
+++ b/cli/checkdk.spec
@@ -40,6 +40,11 @@ HIDDEN_IMPORTS = [
     "urllib3",
     "urllib3.contrib",
     "charset_normalizer",
+    "charset_normalizer.md",
+    "charset_normalizer.models",
+    "charset_normalizer.api",
+    "charset_normalizer.legacy",
+    "charset_normalizer.cd",
     "certifi",
     "idna",
     # pyyaml
@@ -71,8 +76,8 @@ HIDDEN_IMPORTS = [
 ]
 
 a = Analysis(
-    ["checkdkcli/main.py"],
-    pathex=["checkdkcli"],
+    ["bootstrap.py"],
+    pathex=["."],
     binaries=[],
     datas=[],
     hiddenimports=HIDDEN_IMPORTS,


### PR DESCRIPTION
Root cause: checkdk.spec pointed PyInstaller at checkdkcli/main.py directly as the entry-point script. PyInstaller runs it as __main__ with no parent package, so line 11 ('from . import __version__') fails with 'attempted relative import with no known parent package'.

Fix: add a bootstrap.py wrapper that uses absolute imports to load checkdkcli.main as a proper package module. Update checkdk.spec to use bootstrap.py as the entry point and fix pathex from 'checkdkcli' to '.' so the package resolves correctly.

Also adds charset_normalizer submodules to HIDDEN_IMPORTS and suppresses a harmless RequestsDependencyWarning in the frozen env.

The pip-installed CLI is completely unaffected — it uses the entry point from pyproject.toml (checkdkcli.main:main), not bootstrap.py.

Tested: ./dist/checkdk --version, --help, auth login all work.

## Summary

<!-- What does this PR do? One or two sentences. -->

Closes #<!-- issue number, if applicable -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] Dependency update
- [ ] CI / tooling

## Changes Made

<!-- Bullet list of what changed and why -->

- 
- 

## Testing

<!-- How did you test this? -->

- [ ] Backend: `pytest tests/ -v` passes
- [ ] Frontend: `npx tsc --noEmit` and `npm run lint` pass
- [ ] Manually tested locally with `docker compose up --build`

## Screenshots (if UI change)

<!-- Before / after screenshots or a short screen recording -->

## Checklist

- [ ] My branch is up to date with `main`
- [ ] I've kept this PR focused (one feature or fix)
- [ ] I've added/updated tests for any changed backend logic
- [ ] I've updated the README if this adds a user-visible change
- [ ] I haven't committed secrets, `.env` files, or build artifacts
