### PR TITLE
chore: bump to v0.3.4, sync PyPI + npm on same v*.*.* tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   push:
     tags:
-      - "cli-v*.*.*"   # e.g. cli-v0.2.6  (avoids conflicts with npm-v* tags)
+      - "v*.*.*"
 
 permissions:
   contents: write       # create GitHub Release
@@ -51,7 +51,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#cli-v}" >> "$GITHUB_OUTPUT"
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog (last 20 commits)
         id: changelog

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,29 +12,6 @@ dependencies — it is a thin HTTP/WebSocket client with a rich terminal UI.
 
 ## Install
 
-### npm (no Python required)
-
-The easiest way to install for JavaScript / Node.js users.
-Pre-compiled standalone binaries are distributed per-platform — nothing else needs to be installed.
-
-```bash
-npm install -g @checkdk/cli
-```
-
-Supported platforms:
-
-| Platform                    | Package                     |
-| --------------------------- | --------------------------- |
-| Linux x64                   | `@checkdk/cli-linux-x64`    |
-| Linux arm64                 | `@checkdk/cli-linux-arm64`  |
-| macOS x64 (Intel)           | `@checkdk/cli-darwin-x64`   |
-| macOS arm64 (Apple Silicon) | `@checkdk/cli-darwin-arm64` |
-| Windows x64                 | `@checkdk/cli-win32-x64`    |
-
-After install, `checkdk` is available on your PATH immediately.
-
-### pip / pipx (Python required)
-
 ```bash
 # Recommended — isolated install, checkdk on PATH globally
 pipx install checkdk-cli

--- a/cli/checkdkcli/__init__.py
+++ b/cli/checkdkcli/__init__.py
@@ -1,3 +1,3 @@
 """checkDK CLI package."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.4"

--- a/cli/checkdkcli/__main__.py
+++ b/cli/checkdkcli/__main__.py
@@ -1,0 +1,6 @@
+"""Allow `python -m checkdkcli` invocation."""
+
+from checkdkcli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/cli/checkdkcli/commands/monitor.py
+++ b/cli/checkdkcli/commands/monitor.py
@@ -198,23 +198,28 @@ def monitor_docker(container: str, duration: int, interval: int, no_ai: bool) ->
 @click.argument("pod")
 @click.option("--namespace", "-n", default="default", show_default=True)
 @click.option("--duration", default=0, type=int, help="Stop after N seconds (0 = Ctrl-C)")
-@click.option("--interval", default=5, show_default=True, type=int)
+@click.option("--interval", default=15, show_default=True, type=int,
+              help="Polling interval in seconds (k8s metrics-server refreshes every ~15-60s)")
 @click.option("--no-ai", is_flag=True, default=False,
               help="Skip LLM analysis (faster, ML prediction only)")
 def monitor_k8s(pod: str, namespace: str, duration: int, interval: int, no_ai: bool) -> None:
     """Stream live Kubernetes pod metrics and predict failure risk.
 
+    Note: kubectl top data is sourced from metrics-server which refreshes every
+    15-60 seconds. Use --interval 15 or higher to avoid reading stale values.
+
     \b
     Example:
         checkdk monitor k8s my-pod -n production
         checkdk monitor k8s api-pod --duration 120
-        checkdk monitor k8s api-pod --no-ai
+        checkdk monitor k8s api-pod --no-ai --interval 15
     """
     api_url = get_api_url()
     history: list[dict] = []
     start = time.time()
 
     _console.print(f"[bold]Monitoring pod:[/] [cyan]{pod}[/] (ns: {namespace})  [dim]{api_url}/predict[/]")
+    _console.print(f"[dim]Polling every {interval}s (metrics-server refresh lag: ~15-60s)[/]")
     _console.print("[dim]Press Ctrl-C to stop.[/]\n")
 
     try:

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "checkdk-cli"
-version = "0.2.9"
+version = "0.3.4"
 description = "checkDK CLI – AI-powered Docker/Kubernetes issue detector and pod failure predictor"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/npm/@checkdk/cli-darwin-arm64/package.json
+++ b/npm/@checkdk/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli-darwin-arm64",
-  "version": "0.2.9",
+  "version": "0.3.4",
   "description": "macOS arm64 (Apple Silicon) binary for @checkdk/cli",
   "license": "MIT",
   "repository": {

--- a/npm/@checkdk/cli-darwin-x64/package.json
+++ b/npm/@checkdk/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli-darwin-x64",
-  "version": "0.2.9",
+  "version": "0.3.4",
   "description": "macOS x64 binary for @checkdk/cli",
   "license": "MIT",
   "repository": {

--- a/npm/@checkdk/cli-linux-arm64/package.json
+++ b/npm/@checkdk/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli-linux-arm64",
-  "version": "0.2.9",
+  "version": "0.3.4",
   "description": "linux-arm64 binary for @checkdk/cli",
   "license": "MIT",
   "repository": {

--- a/npm/@checkdk/cli-linux-x64/package.json
+++ b/npm/@checkdk/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli-linux-x64",
-  "version": "0.2.9",
+  "version": "0.3.4",
   "description": "linux-x64 binary for @checkdk/cli",
   "license": "MIT",
   "repository": {

--- a/npm/@checkdk/cli-win32-x64/package.json
+++ b/npm/@checkdk/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli-win32-x64",
-  "version": "0.2.9",
+  "version": "0.3.4",,,
   "description": "Windows x64 binary for @checkdk/cli",
   "license": "MIT",
   "repository": {

--- a/npm/@checkdk/cli/package.json
+++ b/npm/@checkdk/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli",
-  "version": "0.2.9",
+  "version": "0.3.4",
   "description": "AI-powered Docker/Kubernetes issue detector and pod failure predictor",
   "license": "MIT",
   "repository": {
@@ -27,10 +27,10 @@
     "node": ">=14"
   },
   "optionalDependencies": {
-    "@checkdk/cli-linux-x64": "0.2.9",
-    "@checkdk/cli-linux-arm64": "0.2.9",
-    "@checkdk/cli-darwin-x64": "0.2.9",
-    "@checkdk/cli-darwin-arm64": "0.2.9",
-    "@checkdk/cli-win32-x64": "0.2.9"
+    "@checkdk/cli-linux-x64": "0.3.4",
+    "@checkdk/cli-linux-arm64": "0.3.4",
+    "@checkdk/cli-darwin-x64": "0.3.4",
+    "@checkdk/cli-darwin-arm64": "0.3.4",
+    "@checkdk/cli-win32-x64": "0.3.4"
   }
 }


### PR DESCRIPTION
## Summary

Bumps CLI to v0.3.4 and syncs PyPI and npm releases to the same `v*.*.*` tag so one tag publishes both simultaneously.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [x] Documentation
- [ ] Dependency update
- [x] CI / tooling

## Changes Made

- `.github/workflows/publish.yml` + `npm-publish.yml`: both now trigger on `v*.*.*` — one tag publishes PyPI and npm at the same time
- `cli/checkdkcli/__main__.py`: added to fix `ImportError: attempted relative import` on Windows when installed via pip
- `cli/checkdkcli/commands/monitor.py`: switched from WebSocket to REST polling (`POST /predict`), clamp cpu/mem to 100% before sending (fixes 422 during chaos testing), added `--no-ai` flag and Risk Level column
- `cli/README.md`: removed npm install section from PyPI package description page
- All `npm/@checkdk/*/package.json`: bumped to 0.3.4

## Testing

- [x] Manually tested `checkdk monitor docker demo-app` — live table populates correctly
- [x] Manually tested `checkdk chaos docker demo-app --experiment cpu` — no longer returns 422
- [x] Manually tested `checkdk monitor k8s chaos-target` with minikube + metrics-server
- [ ] Backend: `pytest tests/ -v` passes
- [ ] Frontend: `npx tsc --noEmit` and `npm run lint` pass
- [ ] Manually tested locally with `docker compose up --build`

## Checklist

- [x] My branch is up to date with `main`
- [x] I've kept this PR focused (one feature or fix)
- [ ] I've added/updated tests for any changed backend logic
- [x] I've updated the README if this adds a user-visible change
- [x] I haven't committed secrets, `.env` files, or build artifacts