### PR TITLE
fix: models page returns no data after login

### DIFF
--- a/backend/checkdk/api/routes/models.py
+++ b/backend/checkdk/api/routes/models.py
@@ -1,76 +1,50 @@
 """
 Routes: /models
 
-Exposes ML model metadata (metrics, feature importances) by reading metrics.json
-files written by the training scripts, and proxies prediction requests to the
-standalone ml-models inference service.
+Exposes Random Forest model metadata (metrics, feature importances) from the
+artifacts baked into the Docker image at build time, and handles prediction
+requests in-process using RFPredictor.
 """
 
 import json
 import logging
 import os
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from ...auth.dependencies import get_current_user
+from ...ml.predictor import ARTIFACTS_DIR as _ARTIFACTS_DIR
+from ...ml.predictor import PodMetrics, RFPredictor
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# ── Configuration ──────────────────────────────────────────────────────────────
+# ── Registry (single trained model) ───────────────────────────────────────────
 
-# Path where ./ml-models/models/ is bind-mounted (read-only) into the backend.
-ML_MODELS_DIR = os.getenv("ML_MODELS_DIR", "/app/ml_models_data")
-
-# Internal Docker hostname for the ml-models FastAPI inference service.
-ML_MODELS_API_URL = os.getenv("ML_MODELS_API_URL", "http://ml-models:8000")
-
-# Registry: (key used in API) → (subdirectory name, display info)
 _REGISTRY = [
     {
         "key": "random_forest",
         "display_name": "Random Forest",
-        "algorithm": "RandomForestClassifier (200 trees, balanced)",
-        "dir": "random_forest",
-        "endpoint": "random-forest",
-    },
-    {
-        "key": "xgboost",
-        "display_name": "XGBoost",
-        "algorithm": "XGBClassifier (300 trees, lr=0.05, hist)",
-        "dir": "xgboost_model",
-        "endpoint": "xgboost",
-    },
-    {
-        "key": "lstm",
-        "display_name": "LSTM",
-        "algorithm": "Stacked LSTM (2 layers, hidden=64, dropout=0.3)",
-        "dir": "lstm_model",
-        "endpoint": "lstm",
+        "algorithm": "RandomForestClassifier (200 trees, balanced weights)",
     },
 ]
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
-def _read_metrics(model_dir: str) -> Optional[Dict[str, Any]]:
-    """Read metrics.json for a model; return None if not found or unreadable."""
-    path = Path(ML_MODELS_DIR) / model_dir / "metrics.json"
-    if not path.exists():
+def _read_metrics() -> Optional[Dict[str, Any]]:
+    """Read metrics.json saved by train.py; return None if unavailable."""
+    path = os.path.join(_ARTIFACTS_DIR, "metrics.json")
+    if not os.path.exists(path):
         return None
     try:
-        with open(path) as f:
-            return json.load(f)
-    except json.JSONDecodeError as exc:
-        logger.error("Corrupt metrics.json for %s: %s", model_dir, exc)
-        return None
-    except OSError as exc:
-        logger.error("Cannot read metrics.json for %s: %s", model_dir, exc)
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error("Cannot read metrics.json: %s", exc)
         return None
 
 
@@ -117,76 +91,83 @@ class PodMetricsInput(BaseModel):
 @router.get("/models", response_model=Dict[str, Any])
 async def list_models(current_user: dict = Depends(get_current_user)):
     """
-    Return metadata and performance metrics for all three ML models.
-    Models that haven't been trained yet return `trained: false`.
+    Return metadata and performance metrics for the Random Forest model.
     """
-    result: List[Dict[str, Any]] = []
+    raw = _read_metrics()
+    entry = _REGISTRY[0]
 
-    for entry in _REGISTRY:
-        raw = _read_metrics(entry["dir"])
-        if raw:
-            fi = raw.get("feature_importances")
-            result.append({
-                "key": entry["key"],
-                "display_name": entry["display_name"],
-                "algorithm": entry["algorithm"],
-                "trained": True,
-                "trained_at": raw.get("trained_at"),
-                "metrics": {
-                    "accuracy": raw.get("accuracy"),
-                    "precision": raw.get("precision"),
-                    "recall": raw.get("recall"),
-                    "f1": raw.get("f1"),
-                    "roc_auc": raw.get("roc_auc"),
-                    "confusion_matrix": raw.get("confusion_matrix"),
-                    "feature_importances": fi,
-                },
-            })
-        else:
-            result.append({
-                "key": entry["key"],
-                "display_name": entry["display_name"],
-                "algorithm": entry["algorithm"],
-                "trained": False,
-                "trained_at": None,
-                "metrics": None,
-            })
+    if raw:
+        fi = raw.get("feature_importances")
+        model_data: Dict[str, Any] = {
+            "key": entry["key"],
+            "display_name": entry["display_name"],
+            "algorithm": entry["algorithm"],
+            "trained": True,
+            "trained_at": raw.get("trained_at"),
+            "metrics": {
+                "accuracy":            raw.get("accuracy"),
+                "precision":           raw.get("precision"),
+                "recall":              raw.get("recall"),
+                "f1":                  raw.get("f1"),
+                "roc_auc":             raw.get("roc_auc"),
+                "confusion_matrix":    raw.get("confusion_matrix"),
+                "feature_importances": fi,
+            },
+        }
+    else:
+        model_data = {
+            "key":          entry["key"],
+            "display_name": entry["display_name"],
+            "algorithm":    entry["algorithm"],
+            "trained":      RFPredictor.is_available(),
+            "trained_at":   None,
+            "metrics":      None,
+        }
 
-    return {"models": result}
+    return {"models": [model_data]}
 
 
 @router.post("/models/predict/{model_key}", response_model=Dict[str, Any])
-async def predict_with_model(model_key: str, metrics: PodMetricsInput, current_user: dict = Depends(get_current_user)):
+async def predict_with_model(
+    model_key: str,
+    metrics: PodMetricsInput,
+    current_user: dict = Depends(get_current_user),
+):
     """
-    Proxy a prediction request to the ml-models inference service.
-    model_key: one of 'random_forest', 'xgboost', or 'lstm'.
+    Run a pod failure prediction using the Random Forest model.
     """
-    entry = next((e for e in _REGISTRY if e["key"] == model_key), None)
-    if entry is None:
+    if model_key != "random_forest":
         raise HTTPException(
             status_code=404,
-            detail=f"Unknown model key '{model_key}'. Valid: random_forest, xgboost, lstm.",
+            detail=f"Unknown model key '{model_key}'. Valid: random_forest.",
         )
 
-    url = f"{ML_MODELS_API_URL}/predict/{entry['endpoint']}"
+    predictor = RFPredictor.get()
+    if predictor is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Random Forest model artifacts are unavailable. "
+                "The model may not have been trained before deployment."
+            ),
+        )
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        try:
-            resp = await client.post(url, json=metrics.model_dump())
-            resp.raise_for_status()
-            return resp.json()
-        except httpx.ConnectError:
-            raise HTTPException(
-                status_code=503,
-                detail="ML models service is unavailable. Start it with docker compose up.",
-            )
-        except httpx.TimeoutException:
-            raise HTTPException(
-                status_code=503,
-                detail="ML models service timed out. The model may still be loading.",
-            )
-        except httpx.HTTPStatusError as exc:
-            raise HTTPException(
-                status_code=exc.response.status_code,
-                detail=exc.response.text,
-            )
+    pod_metrics = PodMetrics(
+        cpu_usage=metrics.cpu_usage,
+        memory_usage=metrics.memory_usage,
+        disk_usage=metrics.disk_usage,
+        network_latency=metrics.network_latency,
+        restart_count=metrics.restart_count,
+        probe_failures=metrics.probe_failures,
+        node_cpu_pressure=metrics.node_cpu_pressure,
+        node_memory_pressure=metrics.node_memory_pressure,
+        pod_age_minutes=metrics.pod_age_minutes,
+    )
+
+    result = predictor.predict(pod_metrics)
+    return {
+        "model":      "random_forest",
+        "prediction": result.prediction,
+        "label":      result.label,
+        "confidence": result.confidence,
+    }

--- a/backend/checkdk/ml/train.py
+++ b/backend/checkdk/ml/train.py
@@ -10,14 +10,17 @@ The dataset is resolved from the following locations in order:
   3. ~/.checkdk/pod_failure_dataset.csv                (user-installed path)
 """
 
+import json
 import os
 import sys
+from datetime import datetime, timezone
 
 ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "artifacts")
 os.makedirs(ARTIFACTS_DIR, exist_ok=True)
 
-MODEL_PATH  = os.path.join(ARTIFACTS_DIR, "rf_model.pkl")
-SCALER_PATH = os.path.join(ARTIFACTS_DIR, "scaler.pkl")
+MODEL_PATH   = os.path.join(ARTIFACTS_DIR, "rf_model.pkl")
+SCALER_PATH  = os.path.join(ARTIFACTS_DIR, "scaler.pkl")
+METRICS_PATH = os.path.join(ARTIFACTS_DIR, "metrics.json")
 
 FEATURES = [
     "cpu_usage",
@@ -67,7 +70,6 @@ def train():
         from sklearn.ensemble import RandomForestClassifier
         from sklearn.model_selection import train_test_split
         from sklearn.preprocessing import StandardScaler
-        from sklearn.metrics import classification_report, roc_auc_score
     except ImportError as e:
         print(f"[train] Missing dependency: {e}")
         print("Run: pip install scikit-learn pandas numpy joblib")
@@ -102,14 +104,50 @@ def train():
     y_pred  = clf.predict(X_test)
     y_proba = clf.predict_proba(X_test)[:, 1]
 
+    from sklearn.metrics import (
+        accuracy_score, precision_score, recall_score, f1_score,
+        roc_auc_score, confusion_matrix,
+    )
+
+    accuracy  = float(accuracy_score(y_test, y_pred))
+    precision = float(precision_score(y_test, y_pred, zero_division=0))
+    recall    = float(recall_score(y_test, y_pred, zero_division=0))
+    f1        = float(f1_score(y_test, y_pred, zero_division=0))
+    roc_auc   = float(roc_auc_score(y_test, y_proba))
+    cm        = confusion_matrix(y_test, y_pred).tolist()
+
+    feature_importances = [
+        {"feature": feat, "importance": round(float(imp), 6)}
+        for feat, imp in sorted(
+            zip(FEATURES, clf.feature_importances_),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+    ]
+
     print("\n=== Random Forest — Evaluation ===")
+    from sklearn.metrics import classification_report
     print(classification_report(y_test, y_pred, target_names=["healthy", "failure"]))
-    print(f"ROC-AUC: {roc_auc_score(y_test, y_proba):.4f}")
+    print(f"ROC-AUC: {roc_auc:.4f}")
 
     joblib.dump(clf,    MODEL_PATH)
     joblib.dump(scaler, SCALER_PATH)
     print(f"\n[train] Model  → {MODEL_PATH}")
     print(f"[train] Scaler → {SCALER_PATH}")
+
+    metrics_data = {
+        "trained_at":          datetime.now(timezone.utc).isoformat(),
+        "accuracy":            round(accuracy, 4),
+        "precision":           round(precision, 4),
+        "recall":              round(recall, 4),
+        "f1":                  round(f1, 4),
+        "roc_auc":             round(roc_auc, 4),
+        "confusion_matrix":    cm,
+        "feature_importances": feature_importances,
+    }
+    with open(METRICS_PATH, "w", encoding="utf-8") as fh:
+        json.dump(metrics_data, fh, indent=2)
+    print(f"[train] Metrics → {METRICS_PATH}")
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/models/ModelsTab.tsx
+++ b/frontend/src/components/models/ModelsTab.tsx
@@ -62,7 +62,7 @@ export default function ModelsTab({ token }: { token: string }) {
             <p className="font-semibold mb-1">Failed to load model metadata</p>
             <p className="text-red-400 text-xs font-mono">{error}</p>
             <p className="text-slate-500 text-xs mt-2">
-              Make sure the backend and ml-models services are running, and models have been trained.
+              Make sure the backend is running and the model has been trained.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The Models dashboard tab was broken in production: the backend tried to read `metrics.json` from a bind-mounted filesystem path and proxy predictions to a separate `ml-models` microservice — neither of which exist in App Runner. This PR removes both external dependencies, reduces the registry to the single trained model (Random Forest), and serves all data in-process from the artifacts baked into the Docker image.

Closes #45 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] CI / tooling

## Changes Made

- **`backend/checkdk/ml/train.py`** — save `metrics.json` (accuracy, precision, recall, f1, roc_auc, confusion matrix, feature importances) to the artifacts directory alongside the model at training time; the Dockerfile trainer stage bakes this directory into the final image
- **`backend/checkdk/api/routes/models.py`** — remove `ML_MODELS_DIR`, `ML_MODELS_API_URL`, httpx proxy, and the XGBoost/LSTM registry entries; `GET /models` reads `metrics.json` from `ARTIFACTS_DIR`; `POST /models/predict/random_forest` calls `RFPredictor` in-process instead of proxying to the dead microservice
- **`frontend/src/components/models/ModelsTab.tsx`** — remove stale "ml-models services" reference from the error state message

## Testing

- [ ] Backend: `pytest tests/ -v` passes
- [ ] Frontend: `npx tsc --noEmit` and `npm run lint` pass
- [x] Manually tested locally with `docker compose up --build`

## Screenshots (if UI change)

- Before
<img width="1919" height="1046" alt="Screenshot From 2026-03-08 09-52-28" src="https://github.com/user-attachments/assets/8cf0bd49-8fd2-48ce-bd16-df59cc7ebd7d" />

- After
<img width="1919" height="1046" alt="image" src="https://github.com/user-attachments/assets/5c94d4f1-891c-4a64-9766-478161ad41bd" />


## Checklist

- [x] My branch is up to date with `main`
- [x] I've kept this PR focused (one feature or fix)
- [ ] I've added/updated tests for any changed backend logic
- [ ] I've updated the README if this adds a user-visible change
- [x] I haven't committed secrets, `.env` files, or build artifacts