### PR TITLE
refactored the readme to include cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # checkDK
 
-**AI-powered Docker Compose & Kubernetes configuration validator — available at [checkdk.app](https://checkdk.app)**
+**AI-powered Docker Compose & Kubernetes configuration validator**
 
 Catch port conflicts, security misconfigurations, missing health probes, and more before they cost you time in production. Upload a config file, get an instant analysis with AI-generated fix suggestions, and keep a searchable history of every scan.
+
+[![Website](https://img.shields.io/badge/website-checkdk.app-4f46e5)](https://checkdk.app)
+[![npm](https://img.shields.io/npm/v/%40checkdk%2Fcli?label=npm&color=cb3837)](https://www.npmjs.com/package/@checkdk/cli)
+[![PyPI](https://img.shields.io/pypi/v/checkdk-cli?label=PyPI&color=3775a9)](https://pypi.org/project/checkdk-cli/)
 
 ---
 
@@ -72,7 +76,6 @@ GOOGLE_CLIENT_SECRET=
 
 # JWT
 JWT_SECRET=change-me-to-a-long-random-string
-
 # AI providers (optional — analysis still works without them)
 GROQ_API_KEY=
 MISTRAL_API_KEY=
@@ -213,7 +216,7 @@ Required GitHub repository secrets:
 | 2     | Auth + Database (GitHub/Google OAuth, JWT, DynamoDB history)         | ✅ Complete |
 | 3     | Post-login app interface (dashboard, playground, get-started)        | ✅ Complete |
 | 4     | CI/CD (GitHub Actions — pytest, lint, ECR deploy, S3 sync)           | ✅ Complete |
-| 5     | Real-time monitoring (WebSocket pod metrics stream, recharts)        | 🔲 Planned  |
+| 5     | Real-time monitoring (REST-polled pod metrics, risk scoring, CLI)    | ✅ Complete |
 | 6     | Chaos dataset + ML retraining (real EKS failure data via Chaos Mesh) | 🔲 Planned  |
 | 7     | Amazon Bedrock (replace Mistral with Claude Haiku via IAM role)      | 🔲 Planned  |
 
@@ -221,22 +224,20 @@ Required GitHub repository secrets:
 
 ## ML Prediction API
 
-The backend exposes four prediction endpoints for Kubernetes pod failure risk:
+The backend exposes a Random Forest prediction endpoint for pod failure risk:
 
-| Endpoint                      | Model                          |
-| ----------------------------- | ------------------------------ |
-| `POST /predict/random-forest` | scikit-learn RandomForest      |
-| `POST /predict/xgboost`       | XGBoost                        |
-| `POST /predict/lstm`          | PyTorch LSTM                   |
-| `POST /predict/ensemble`      | Majority vote across all three |
+| Endpoint                      | Model                     |
+| ----------------------------- | ------------------------- |
+| `POST /predict`               | scikit-learn RandomForest |
 
 **Request fields:** `cpu_usage`, `memory_usage`, `disk_usage`, `network_latency`, `restart_count`, `probe_failures`, `node_cpu_pressure`, `node_memory_pressure`, `pod_age_minutes`
 
-Example — ensemble prediction (failure case):
+Example — failure case:
 
 ```bash
-curl -X POST https://checkdk.app/api/predict/ensemble \
+curl -X POST https://checkdk.app/api/predict \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{
     "cpu_usage": 94.5,
     "memory_usage": 96.2,
@@ -252,11 +253,11 @@ curl -X POST https://checkdk.app/api/predict/ensemble \
 
 ```json
 {
-  "ensemble_label": "failure",
-  "ensemble_confidence": 0.87,
-  "random_forest": { "label": "failure", "confidence": 0.62 },
-  "xgboost": { "label": "failure", "confidence": 1.0 },
-  "lstm": { "label": "failure", "confidence": 1.0 }
+  "prediction": 1,
+  "label": "failure",
+  "confidence": 0.87,
+  "risk_level": "critical",
+  "ai_analysis": "..."
 }
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -112,14 +112,24 @@ checkdk predict --cpu 85 --memory 70 --json             # CI/scripting output
 
 ### Monitor (real-time)
 
-Streams live metrics to the API over WebSocket and displays failure risk in a
-Rich Live table. Requires the container/pod to be running.
+Polls live container/pod metrics and sends each sample to the prediction API,
+displaying failure risk, confidence, and risk level in a Rich Live table.
+Requires the container/pod to be running.
 
 ```bash
 checkdk monitor docker my-container
 checkdk monitor docker my-container --duration 120 --interval 3
+checkdk monitor docker my-container --no-ai          # ML prediction only, skip LLM
 checkdk monitor k8s my-pod -n production
+checkdk monitor k8s my-pod -n production --no-ai
 ```
+
+| Option       | Default | Description                                   |
+| ------------ | ------- | --------------------------------------------- |
+| `--duration` | 60      | How long to monitor, in seconds               |
+| `--interval` | 5       | Seconds between each sample                   |
+| `--no-ai`    | —       | Skip LLM analysis, return ML risk score only  |
+| `-n`         | default | Kubernetes namespace (k8s only)               |
 
 ### Chaos
 


### PR DESCRIPTION
## Summary

Refactor `README.md` and `cli/README.md` to reflect the current state of the project: single Random Forest model (no XGBoost/LSTM/ensemble), REST-polled monitor (no WebSocket), corrected roadmap, and added version/website badges.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] Dependency update
- [ ] CI / tooling

## Changes Made

- **`README.md`** — replaced inline website link in heading with a badges row (website, npm, PyPI); removed dead XGBoost/LSTM/ensemble endpoints from ML Prediction API section; updated `POST /predict` example to match actual response shape; marked roadmap item 5 (monitoring) as complete
- **`cli/README.md`** — rewrote Monitor section to describe REST polling instead of WebSocket; added `--no-ai` flag usage and a full options table for `checkdk monitor`

## Testing

- [ ] Backend: `pytest tests/ -v` passes
- [ ] Frontend: `npx tsc --noEmit` and `npm run lint` pass
- [x] Manually reviewed for accuracy against the current codebase

## Checklist

- [x] My branch is up to date with `main`
- [x] I've kept this PR focused (one feature or fix)
- [ ] I've added/updated tests for any changed backend logic
- [x] I've updated the README if this adds a user-visible change
- [x] I haven't committed secrets, `.env` files, or build artifacts