### PR TITLE
fix: remove extra commas in win32-x64 package.json

### DIFF
--- a/npm/@checkdk/cli-win32-x64/package.json
+++ b/npm/@checkdk/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdk/cli-win32-x64",
-  "version": "0.3.4",,,
+  "version": "0.3.4",
   "description": "Windows x64 binary for @checkdk/cli",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Had a small error in npm so it was not getting packaged.