### PR TITLE
added changes to ignore if already published

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -206,30 +206,65 @@ jobs:
 
       - name: Publish @checkdk/cli-linux-x64
         working-directory: npm/@checkdk/cli-linux-x64
-        run: npm publish --access public
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          PKG=$(node -e "console.log(require('./package.json').name)")
+          if npm view "${PKG}@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
+            echo "${PKG}@${VERSION} already published — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @checkdk/cli-linux-arm64
         working-directory: npm/@checkdk/cli-linux-arm64
-        run: npm publish --access public
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          PKG=$(node -e "console.log(require('./package.json').name)")
+          if npm view "${PKG}@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
+            echo "${PKG}@${VERSION} already published — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @checkdk/cli-darwin-arm64
         working-directory: npm/@checkdk/cli-darwin-arm64
-        run: npm publish --access public
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          PKG=$(node -e "console.log(require('./package.json').name)")
+          if npm view "${PKG}@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
+            echo "${PKG}@${VERSION} already published — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @checkdk/cli-win32-x64
         working-directory: npm/@checkdk/cli-win32-x64
-        run: npm publish --access public
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          PKG=$(node -e "console.log(require('./package.json').name)")
+          if npm view "${PKG}@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
+            echo "${PKG}@${VERSION} already published — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @checkdk/cli
         working-directory: npm/@checkdk/cli
-        run: npm publish --access public
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          PKG=$(node -e "console.log(require('./package.json').name)")
+          if npm view "${PKG}@${VERSION}" version 2>/dev/null | grep -q "${VERSION}"; then
+            echo "${PKG}@${VERSION} already published — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: cli/dist/
+          skip-existing: true
 
   # ── 2. Create GitHub Release ────────────────────────────────────────────────
   github-release:


### PR DESCRIPTION
This pull request updates the publishing workflows to avoid errors and redundant publishing of already existing package versions. The workflows now check if a package version is already published before attempting to publish, and also add a flag to skip uploading existing Python packages.

Improvements to npm package publishing:

* Updated all npm publish steps in `.github/workflows/npm-publish.yml` to check if the package version already exists before publishing, preventing duplicate publishes and errors.

Improvements to Python package publishing:

* Added the `skip-existing: true` flag to the PyPI publish step in `.github/workflows/publish.yml`, allowing the workflow to skip uploading packages that already exist on PyPI.