### PR TITLE
fix: LLM max_tokens 400→700, fix response parser, fix CLI display

### DIFF
--- a/backend/checkdk/ai/providers.py
+++ b/backend/checkdk/ai/providers.py
@@ -212,47 +212,64 @@ Be concise and practical. Focus on the highest-impact metrics."""
 
     @staticmethod
     def _parse_pod_health_response(response: str) -> dict:
-        """Parse a free-text pod health response into structured dict."""
+        """Parse a free-text pod health response into structured dict.
+
+        Handles both inline style  (``**Assessment**: text``)
+        and block style           (``## Assessment\n\ntext…``)
+        and accumulates multi-line content for each section.
+        """
+        _strip_md_markers = lambda s: re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", s).strip()
+
         lines = response.strip().split("\n")
         result: dict = {"assessment": "", "root_cause": "", "recommendations": []}
         current_section: str | None = None
+        section_lines: dict = {"assessment": [], "root_cause": []}
 
         for line in lines:
-            line = line.strip()
-            if not line:
+            stripped = line.strip()
+            if not stripped:
                 continue
-            lower = line.lower()
-            if "assessment" in lower and ":" in line:
+            lower = stripped.lower()
+            # Detect section header regardless of colon or ## prefix
+            is_header = ":" in stripped or stripped.startswith("#") or stripped.startswith("**")
+            if "assessment" in lower and is_header and "root cause" not in lower:
                 current_section = "assessment"
-                parts = line.split(":", 1)
-                if len(parts) > 1 and parts[1].strip():
-                    result["assessment"] = parts[1].strip()
-            elif "root cause" in lower and ":" in line:
+                if ":" in stripped:
+                    inline = stripped.split(":", 1)[1].strip()
+                    inline = _strip_md_markers(inline)
+                    if inline:
+                        section_lines["assessment"].append(inline)
+            elif "root cause" in lower and is_header:
                 current_section = "root_cause"
-                parts = line.split(":", 1)
-                if len(parts) > 1 and parts[1].strip():
-                    result["root_cause"] = parts[1].strip()
-            elif "recommendation" in lower and ":" in line:
+                if ":" in stripped:
+                    inline = stripped.split(":", 1)[1].strip()
+                    inline = _strip_md_markers(inline)
+                    if inline:
+                        section_lines["root_cause"].append(inline)
+            elif "recommendation" in lower and is_header:
                 current_section = "recommendations"
-            elif current_section == "recommendations" and (
-                line.startswith("-")
-                or line.startswith("•")
-                or line.startswith("*")
-                or (len(line) > 0 and line[0].isdigit())
-            ):
-                clean = line.lstrip("-•*0123456789. ").strip()
-                if clean:
-                    result["recommendations"].append(clean)
-            elif current_section in ("assessment", "root_cause") and not any(
-                x in lower for x in ("assessment", "root cause", "recommendation")
-            ):
-                if current_section == "assessment" and not result["assessment"]:
-                    result["assessment"] = line
-                elif current_section == "root_cause" and not result["root_cause"]:
-                    result["root_cause"] = line
+            elif current_section == "recommendations":
+                if (
+                    stripped.startswith("-")
+                    or stripped.startswith("•")
+                    or stripped.startswith("*")
+                    or (stripped and stripped[0].isdigit())
+                ):
+                    clean = re.sub(r"^[-•*\d.)\s]+", "", stripped).strip()
+                    clean = _strip_md_markers(clean)
+                    if clean:
+                        result["recommendations"].append(clean)
+            elif current_section in ("assessment", "root_cause"):
+                if not any(x in lower for x in ("assessment", "root cause", "recommendation")):
+                    section_lines[current_section].append(_strip_md_markers(stripped))
+
+        result["assessment"] = " ".join(section_lines["assessment"]).strip()
+        result["root_cause"] = " ".join(section_lines["root_cause"]).strip()
 
         if not result["assessment"]:
-            result["assessment"] = response[:250]
+            # Fallback: strip ## headers then use first 300 chars
+            clean_response = re.sub(r"^#+\s+.*$", "", response, flags=re.MULTILINE).strip()
+            result["assessment"] = clean_response[:300]
         return result
 
     @staticmethod
@@ -324,7 +341,7 @@ class MistralProvider(AIProvider):
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.3,
-                max_tokens=400,
+                max_tokens=700,
             )
             text = response.choices[0].message.content or ""
             return self._parse_pod_health_response(text)
@@ -417,7 +434,7 @@ class GroqProvider(AIProvider):
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.3,
-                max_tokens=400,
+                max_tokens=700,
             )
             text = response.choices[0].message.content or ""
             return self._parse_pod_health_response(text)

--- a/cli/checkdkcli/display.py
+++ b/cli/checkdkcli/display.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from rich.console import Console
+import re
+
+from rich.console import Console, Group
+from rich.markdown import Markdown
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 console = Console()
 
@@ -57,18 +62,20 @@ def display_analysis_result(result: dict) -> None:
                 if is_ai:
                     console.print("\n   [bold green]💡 AI-Enhanced Fix:[/]")
                     if fix.get("explanation"):
-                        console.print(f"   [yellow]{fix['explanation']}[/]\n")
+                        console.print(Markdown(fix["explanation"]))
                     if fix.get("root_cause"):
-                        console.print(f"   [bold cyan]Root Cause:[/] {fix['root_cause']}\n")
-                    console.print("   [bold cyan]Steps:[/]")
-                    for step in fix.get("steps", []):
-                        console.print(f"   • {step}")
+                        console.print("   [bold cyan]Root Cause:[/]")
+                        console.print(Markdown(fix["root_cause"]))
+                    if fix.get("steps"):
+                        console.print("   [bold cyan]Steps:[/]")
+                        for step in fix.get("steps", []):
+                            console.print(f"   • {escape(step)}")
                 else:
                     console.print("\n   [bold green]💡 Fix:[/]")
                     if fix.get("description"):
-                        console.print(f"   [dim]{fix['description']}[/]")
+                        console.print(Markdown(fix["description"]))
                     for step in fix.get("steps", []):
-                        console.print(f"   [cyan]{step}[/]")
+                        console.print(f"   [cyan]→[/] {escape(step)}")
 
     if warnings:
         console.print("\n[bold yellow]⚠ Warnings:[/]")
@@ -128,22 +135,99 @@ def display_predict_result(resp: dict, service: str | None, platform: str) -> No
     if not assessment:
         return
 
-    ai_table = Table.grid(padding=(0, 1))
-    ai_table.add_column(style="bold cyan", no_wrap=True)
-    ai_table.add_column()
+    def _recover_sections(a: dict) -> dict:
+        """Client-side recovery for when the backend parser falls back to
+        dumping the raw LLM text into assessment['assessment'].
 
-    if assessment.get("assessment"):
-        ai_table.add_row("Assessment:", assessment["assessment"])
-        ai_table.add_row("", "")
-    if assessment.get("root_cause"):
-        ai_table.add_row("Root Cause:", assessment["root_cause"])
-        ai_table.add_row("", "")
-    if assessment.get("recommendations"):
-        ai_table.add_row("Actions:", "")
-        for i, rec in enumerate(assessment["recommendations"], 1):
-            ai_table.add_row(f"  {i}.", rec)
+        Detects embedded ## / **Label**: section markers and splits them out
+        into the correct keys so the display is always structured correctly.
+        """
+        raw = a.get("assessment", "")
+        # Only attempt recovery when root_cause is missing and the assessment
+        # text looks like it contains multiple embedded sections.
+        section_pattern = re.compile(
+            r"(?:^#{1,6}\s+|\*{1,2})?(assessment|root\s*cause|recommendation)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+        if a.get("root_cause") or not section_pattern.search(raw):
+            return a  # already structured or no sections embedded — nothing to do
 
-    console.print(Panel(ai_table, title="💡 LLM Health Assessment", border_style="cyan"))
+        # Split on ## Header or **Header**: boundaries
+        parts = re.split(
+            r"\n?\s*(?:#{1,6}\s+|\*{1,2})(Assessment|Root\s*Cause|Recommendations?)"
+            r"(?:\*{1,2})?\s*:?\s*\n?",
+            raw,
+            flags=re.IGNORECASE,
+        )
+
+        recovered: dict = {"assessment": "", "root_cause": "", "recommendations": []}
+        i = 0
+        # parts is [pre-text, label, content, label, content, ...]
+        if parts and not re.search(r"assessment|root|recommend", parts[0], re.IGNORECASE):
+            i = 0  # skip leading empty / pre-text
+        while i < len(parts) - 1:
+            label = parts[i].strip().lower() if i < len(parts) else ""
+            content = parts[i + 1].strip() if i + 1 < len(parts) else ""
+            if "assessment" in label:
+                recovered["assessment"] = content
+                i += 2
+            elif "root" in label:
+                recovered["root_cause"] = content
+                i += 2
+            elif "recommend" in label:
+                for line in content.splitlines():
+                    line = line.strip()
+                    clean = re.sub(r"^[-•*\d.)]+\s*", "", line).strip()
+                    if clean:
+                        recovered["recommendations"].append(clean)
+                i += 2
+            else:
+                i += 1
+
+        # Preserve original if recovery produced nothing useful
+        if not recovered["assessment"] and not recovered["root_cause"]:
+            return a
+        # Keep any recommendations already parsed by the backend
+        if not recovered["recommendations"] and a.get("recommendations"):
+            recovered["recommendations"] = a["recommendations"]
+        return recovered
+
+    def _clean(text: str) -> str:
+        """Strip stray ## headers and leading **Label**: markers from a field."""
+        text = re.sub(r"^\s*#{1,6}\s+\S.*$", "", text, flags=re.MULTILINE)
+        text = re.sub(r"^\s*\*{1,2}[^*]+\*{1,2}\s*:\s*", "", text.strip())
+        return text.strip()
+
+    a = _recover_sections(assessment)
+
+    parts: list = []
+
+    if a.get("assessment"):
+        parts.append(Text("Assessment", style="bold cyan"))
+        parts.append(Markdown(_clean(a["assessment"])))
+        parts.append(Text(""))
+
+    if a.get("root_cause"):
+        parts.append(Text("Root Cause", style="bold cyan"))
+        parts.append(Markdown(_clean(a["root_cause"])))
+        parts.append(Text(""))
+
+    if a.get("recommendations"):
+        parts.append(Text("What You Can Do", style="bold cyan"))
+        rec_lines = "\n".join(
+            f"{i}. {_clean(rec)}" for i, rec in enumerate(a["recommendations"], 1)
+        )
+        parts.append(Markdown(rec_lines))
+
+    if parts:
+        console.print(
+            Panel(
+                Group(*parts),
+                title="💡 LLM Health Assessment",
+                border_style="cyan",
+                expand=True,
+            )
+        )
 
 
 # ── Playground display ────────────────────────────────────────────────────────
@@ -206,16 +290,19 @@ def display_playground_result(result: dict, file_path: str = "") -> None:
             if fix:
                 steps = fix.get("steps") or []
                 if fix.get("explanation"):
-                    console.print(f"   [bold green]💡[/] {fix['explanation']}")
+                    console.print("   [bold green]💡 Fix:[/]")
+                    console.print(Markdown(fix["explanation"]))
+                elif steps:
+                    console.print("   [bold green]💡 Fix:[/]")
                 for step in steps:
-                    console.print(f"   [cyan]→[/] {step}")
+                    console.print(f"   [cyan]→[/] {escape(step)}")
 
     # AI highlights
     highlights = result.get("highlights", [])
     if highlights:
         console.print("\n[bold cyan]💡 AI Highlights:[/]")
         for hl in highlights:
-            console.print(f"  [cyan]•[/] {hl}")
+            console.print(Markdown(hl))
 
 
 # ── Monitor display helper ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix LLM Health Assessment output in the CLI: raise `max_tokens` from 400 to 700 so responses are no longer truncated mid-sentence, fix the backend response parser to correctly extract Assessment / Root Cause / Recommendations sections, and rewrite the CLI display to render all three sections inside a single consistent Rich panel matching the ML Prediction box style.

Closes #49

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] CI / tooling

## Changes Made

- **`backend/checkdk/ai/providers.py`** — raised `max_tokens` from 400 to 700 in both Mistral and Groq `analyze_pod_health` calls; fixed section parser to detect `##` and `**` prefixed headers, accumulate all continuation lines instead of dropping after the first, and strip raw Markdown markers from captured field values
- **`cli/checkdkcli/display.py`** — removed `no_wrap` table cell rendering for LLM output; added `_clean_llm_text()` to strip embedded `## Header` artifacts client-side; added `_recover_sections()` to correctly split flat LLM text into Assessment / Root Cause / What You Can Do when the backend returns them concatenated; rewrote `display_predict_result` LLM section to render all three fields inside one `Panel` with `╭─╮` border matching the ML Prediction box

## Testing

- [x] Manually tested `checkdk predict --cpu 93 --memory 91` locally — full Assessment, Root Cause, and What You Can Do sections render without truncation or raw Markdown symbols
- [ ] Backend: `pytest tests/ -v` passes
- [ ] Frontend: `npx tsc --noEmit` and `npm run lint` pass
- [ ] Manually tested locally with `docker compose up --build`

## Checklist

- [x] My branch is up to date with `main`
- [x] I've kept this PR focused (one feature or fix)
- [ ] I've added/updated tests for any changed backend logic
- [ ] I've updated the README if this adds a user-visible change
- [x] I haven't committed secrets, `.env` files, or build artifacts
